### PR TITLE
Get ATAK running on Android 11

### DIFF
--- a/atak/ATAK/app/src/main/java/com/atakmap/android/gui/PluginSpinner.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/gui/PluginSpinner.java
@@ -901,6 +901,9 @@ public class PluginSpinner extends Spinner {
             return c.createConfigurationContext(overrideConfiguration);
         }
 
+        public boolean isUiContext() {
+            return true;
+        }
     }
 
     public static final String TAG = "PluginSpinner";

--- a/atak/ATAK/app/src/main/java/com/atakmap/app/ATAKActivity.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/app/ATAKActivity.java
@@ -1439,7 +1439,7 @@ public class ATAKActivity extends MapActivity implements
                             // system and not from this application.   Warn users for future SDK's
                             // that this might not work when running debug versions - so it can be
                             // checked.
-                            if (Build.VERSION.SDK_INT > 29 && BuildConfig.DEBUG)
+                            if (Build.VERSION.SDK_INT > 30 && BuildConfig.DEBUG)
                                 Log.e(TAG,
                                         "may need to revisit double reflection trick",
                                         new Exception());


### PR DESCRIPTION
* Add `boolean isUiContext()` to `PluginSpinner.ContextSensitiveContext` as Android 11 now invokes this and it must be overridden
* Update the version check in `ATAKActivity.setActionBarHeight()` to allow for Android 11

I'm not sure what the proper way to verify the double reflection trick, but behaviorally I didn't see any issues with the `ActionBar` height when I ran this.