### PR TITLE
Emergency "In Contact" can now be used

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 ## Signed-off-by
 
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
+- 8th Nov 2020, Jon Poulton - jonathanpoulton1@gmail.com
 
 ## Note for U.S. Federal Employees
 

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/emergency/tool/EmergencyType.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/emergency/tool/EmergencyType.java
@@ -6,7 +6,7 @@ public enum EmergencyType {
     Cancel("Cancel Alert", "b-a-o-can", 1),
     GeoFenceBreach("Geo-fence Breached", "b-a-g", 2),
     RingTheBell("Ring The Bell", "b-a-o-pan", 3),
-    TroopsInContact("Troops In Contact", "b-a-o-opn", 4);
+    TroopsInContact("In Contact", "b-a-o-opn", 4);
 
     private final String description;
     private final String cotType;


### PR DESCRIPTION
To reproduce the issue, open the Emergency tool and select the "In Contact" option. Try to enable both switches and the selected emergency type reverts back to "911 Alert". This is because of a difference in string IDs for `R.string.repeater_in_contact` between `strings-civ.xml` and `strings.xml`, which wasn't reflected in the `description` attribute in the `EmergencyType` enum. 

As a result, when `EmergencyType.fromDescription` was called as the second toggle was enabled, the description wasn't found in the for-loop and it defaulted to a 911 alert.

This PR fixes this issue (for ATAK-CIV, at least).

Not sure whether a single-line fix requires it, but i also included the contributors addendum. 