### PR TITLE
4.1.0.1

### DIFF
--- a/.github/workflows/assemble-sdk.yml
+++ b/.github/workflows/assemble-sdk.yml
@@ -25,13 +25,13 @@ jobs:
         sudo apt-get install cmake
         sudo apt-get install swig
         sudo apt-get install tclsh
-        echo ::set-env name=ANDROID_COMPILE_SDK::"29"
-        echo ::set-env name=ANDROID_BUILD_TOOLS::"29.0.3"
-        echo ::set-env name=ANDROID_SDK_TOOLS::"4333796"
-        echo ::set-env name=NDK_VERSION::"12b"
-        echo ::set-env name=KEYSTORE_ALIAS::"CI"
-        echo ::set-env name=KEYSTORE_STORE_PASSWORD::$(apg -a 1 -n 1 -m 16 -x 16 -E '\')
-        echo ::set-env name=KEYSTORE_KEY_PASSWORD::$(apg -a 1 -n 1 -m 16 -x 16 -E '\')
+        echo "ANDROID_COMPILE_SDK=29" >> $GITHUB_ENV
+        echo "ANDROID_BUILD_TOOLS=29.0.3" >> $GITHUB_ENV
+        echo "ANDROID_SDK_TOOLS=4333796" >> $GITHUB_ENV
+        echo "NDK_VERSION=12b" >> $GITHUB_ENV
+        echo "KEYSTORE_ALIAS=CI" >> $GITHUB_ENV
+        echo "KEYSTORE_STORE_PASSWORD=$(apg -a 1 -n 1 -m 16 -x 16 -E '\')" >> $GITHUB_ENV
+        echo "KEYSTORE_KEY_PASSWORD=$(apg -a 1 -n 1 -m 16 -x 16 -E '\')" >> $GITHUB_ENV
         mkdir $HOME/secrets
     - name: set up Android SDK
       run: |
@@ -42,8 +42,8 @@ jobs:
        echo y | android-sdk-linux/tools/bin/sdkmanager "platforms;android-${ANDROID_COMPILE_SDK}" >/dev/null;
        echo y | android-sdk-linux/tools/bin/sdkmanager "platform-tools" >/dev/null;
        echo y | android-sdk-linux/tools/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS}" >/dev/null;
-       echo ::set-env name=ANDROID_HOME::$PWD/android-sdk-linux
-       echo ::set-env name=PATH::$PATH:$PWD/android-sdk-linux/platform-tools/
+       echo "ANDROID_HOME=$PWD/android-sdk-linux" >> $GITHUB_ENV
+       echo "$PWD/android-sdk-linux/platform-tools/" >> $GITHUB_PATH
        set +o pipefail
        yes | android-sdk-linux/tools/bin/sdkmanager --licenses
        set -o pipefail
@@ -51,8 +51,8 @@ jobs:
       run: |
        wget --quiet --tries=0 --output-document=android-ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip;
        unzip -qq  android-ndk.zip;
-       echo ::set-env name=ANDROID_NDK_HOME::$PWD/android-ndk-r${NDK_VERSION}
-       echo ::set-env name=ANDROID_NDK::$PWD/android-ndk-r${NDK_VERSION}
+       echo "ANDROID_NDK_HOME=$PWD/android-ndk-r${NDK_VERSION}" >> $GITHUB_ENV
+       echo "ANDROID_NDK=$PWD/android-ndk-r${NDK_VERSION}" >> $GITHUB_ENV
     - name: Build Dependencies
       run: |
         cd scripts

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,11 @@
 # Version History
 
+## 4.1.0.1
+
+* Adjust Android SDK to use named SDK constants instead of raw numbers
+* Add a Developer Option to skip the drawing of route vertex points to work around crash observed on some custom hardware
+* Fix potential `NullPointerException` on Android 6 in `RemarksLayout`
+
 ## 4.1.0.0
 
 * Bloodhound integration with route planners

--- a/atak/ATAK/app/build.gradle
+++ b/atak/ATAK/app/build.gradle
@@ -21,7 +21,7 @@ import java.util.regex.Pattern
 ////////////////////////////////////////////////////////////////////////////////
 
 def ATAK_VERSION = "4.1.0"
-def ATAK_VERSION_SUBMINOR = ".0"
+def ATAK_VERSION_SUBMINOR = ".1"
 
 buildscript {
     ext.jacocoVersion = '0.8.5'

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/editableShapes/GLEditablePolyline.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/editableShapes/GLEditablePolyline.java
@@ -4,6 +4,7 @@ package com.atakmap.android.editableShapes;
 import com.atakmap.android.maps.MapView;
 import com.atakmap.android.maps.graphics.GLImageCache;
 import com.atakmap.android.maps.graphics.GLPolyline;
+import com.atakmap.app.DeveloperOptions;
 import com.atakmap.app.R;
 import com.atakmap.map.MapRenderer;
 import com.atakmap.map.opengl.GLMapView;
@@ -19,10 +20,17 @@ class GLEditablePolyline extends GLPolyline implements
     private boolean _editable;
     private final EditablePolyline _subject;
 
+    private boolean disableVertexPointDrawing = false;
+
     public GLEditablePolyline(MapRenderer surface, EditablePolyline subject) {
         super(surface, subject);
         _editable = subject.getEditable();
         _subject = subject;
+
+        // working around an issue with the MPU 5 and the GL_POINTS
+        // this is temporary and should be removed as soon as possible but for the
+        // purposes of 4.1.0.1, this is probably the least intrusive bandaid.
+        disableVertexPointDrawing = DeveloperOptions.getIntOption("disable-vertex-points", 0) == 1;
     }
 
     @Override
@@ -91,6 +99,7 @@ class GLEditablePolyline extends GLPolyline implements
                 GLES20FixedPipeline.glEnableClientState(
                         GLES20FixedPipeline.GL_VERTEX_ARRAY);
 
+                if (!disableVertexPointDrawing) {
                 if (dragIndex > -1 && dragIndex < this.numPoints) {
                     // Draw single vertex being dragged
                     GLES20FixedPipeline.glDrawArrays(
@@ -99,6 +108,7 @@ class GLEditablePolyline extends GLPolyline implements
                     // Draw all vertices
                     GLES20FixedPipeline.glDrawArrays(
                             GLES20FixedPipeline.GL_POINTS, 0, this.numPoints);
+                }
                 }
 
                 // Disable features

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/hashtags/view/RemarksLayout.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/hashtags/view/RemarksLayout.java
@@ -28,7 +28,7 @@ public class RemarksLayout extends LinearLayout {
 
     private final HashtagEditText _remarks;
     private final ImageButton _editBtn;
-    private String _rawText;
+    private String _rawText = "";
 
     public RemarksLayout(Context context) {
         this(context, null);

--- a/atak/ATAK/app/src/main/java/com/atakmap/app/DozeManagement.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/app/DozeManagement.java
@@ -169,7 +169,7 @@ class DozeManagement {
 
     static private boolean isIgnoringBatteryOptimizations(Context context,
             String packageName) {
-        if (Build.VERSION.SDK_INT > 23) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             final PowerManager pm = (PowerManager) context
                     .getSystemService(Context.POWER_SERVICE);
             if (pm != null)
@@ -179,7 +179,7 @@ class DozeManagement {
     }
 
     static private boolean isPowerSaveMode(Context context) {
-        if (Build.VERSION.SDK_INT > 23) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             final PowerManager pm = (PowerManager) context
                     .getSystemService(Context.POWER_SERVICE);
             if (pm != null)
@@ -192,7 +192,7 @@ class DozeManagement {
     static private void checkAndWarnRestrictingBackgroundData(
             final Context context) {
 
-        if (android.os.Build.VERSION.SDK_INT < 24) {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             return;
         }
 


### PR DESCRIPTION
* Adjust Android SDK to use named SDK constants instead of raw numbers
* Add a Developer Option to skip the drawing of route vertex points to work around crash observed on some custom hardware
* Fix potential `NullPointerException` on Android 6 in `RemarksLayout`