### PR TITLE
removeOutputsChangedListener() should remove, not add

### DIFF
--- a/atak/ATAK/app/src/main/java/com/atakmap/comms/CommsMapComponent.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/comms/CommsMapComponent.java
@@ -724,7 +724,7 @@ public class CommsMapComponent extends AbstractMapComponent implements
     public void removeOutputsChangedListener(
             CotServiceRemote.OutputsChangedListener listener) {
         synchronized (outputsChangedListeners) {
-            outputsChangedListeners.add(listener);
+            outputsChangedListeners.remove(listener);
         }
     }
 


### PR DESCRIPTION
The removeOutputsChangedListener() function is supposed to remove the specified listener.  But the code adds it instead.
