### PR TITLE
allow use of user installed certificate authorities

### DIFF
--- a/atak/ATAK/app/src/main/AndroidManifest.xml
+++ b/atak/ATAK/app/src/main/AndroidManifest.xml
@@ -173,7 +173,8 @@
         android:usesCleartextTraffic="true"
         android:description="@string/app_desc"
         android:allowBackup="false"
-        android:supportsRtl="false">
+        android:supportsRtl="false"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <meta-data android:name="plugin-api" android:value="${atakApiVersion}"/>
         <meta-data android:name="app_desc" android:value="@string/app_desc"/>

--- a/atak/ATAK/app/src/main/res/xml/network_security_config.xml
+++ b/atak/ATAK/app/src/main/res/xml/network_security_config.xml
@@ -1,8 +1,9 @@
 <network-security-config>    
-    <debug-overrides> 
+    <base-config> 
         <trust-anchors> 
-            <!-- Trust user added CAs -->
-            <certificates src="user" /> 
+          <!-- Trust user added CAs -->
+          <certificates src="system" />
+          <certificates src="user" />
         </trust-anchors>    
-    </debug-overrides>  
+    </base-config>  
 </network-security-config>

--- a/atak/ATAK/app/src/main/res/xml/network_security_config.xml
+++ b/atak/ATAK/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>    
+    <debug-overrides> 
+        <trust-anchors> 
+            <!-- Trust user added CAs -->
+            <certificates src="user" /> 
+        </trust-anchors>    
+    </debug-overrides>  
+</network-security-config>


### PR DESCRIPTION
Right now, if you setup your server with ssl, you need to install 2 certs in ATAK - the Authority and Client certificate, doing this will allow you to receive CoT messages over the socket.  If you want to work with data packages, you need to use the REST API (/Marti endpoints), but in order for that to work over a secure socket, Android needs to trust your server certificate (which has to comes for the same authority as the one used by the CoT socket.  This can be achieved by installing the certificate as a trusted root CA in Android.

The current problem is that apps by default do not see use installed certificates.  This change fixes that.  This also brings it in line with WinTAK, which has access to all the certificates installed in the Windows Certificate Store.

See the following pages for more info about the change I made:
- https://developer.android.com/training/articles/security-config
- https://stackoverflow.com/questions/4461360/how-to-install-trusted-ca-certificate-on-android-device