### PR TITLE
Clear all listeners when disposing MapItem

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 ## Signed-off-by
 
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
+- 07/13/2021, Joshua Soberg, j15soberg@gmail.com
 
 ## Note for U.S. Federal Employees
 

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/maps/MapItem.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/maps/MapItem.java
@@ -682,6 +682,9 @@ public abstract class MapItem extends FilterMetaDataHolder implements
         _typeListeners.clear();
         _clickableListeners.clear();
         _zOrderListeners.clear();
+        _onGroupListeners.clear();
+        _onMetadataChangedListeners.clear();
+        _onHeightChanged.clear();
         group = null;
     }
 


### PR DESCRIPTION
Made sure that all listeners were being cleared when a `MapItem` is disposed (group, metadata, and height change listeners were not being cleared).