### PR TITLE
ANR fixes

### DIFF
--- a/atak/ATAK/app/src/main/java/com/atakmap/android/elev/ElevationOverlaysMapComponent.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/elev/ElevationOverlaysMapComponent.java
@@ -33,6 +33,8 @@ import com.atakmap.map.layer.elevation.TerrainSlopeLayer;
 import com.atakmap.map.layer.opengl.GLLayerFactory;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ElevationOverlaysMapComponent extends AbstractMapComponent
@@ -124,7 +126,14 @@ public class ElevationOverlaysMapComponent extends AbstractMapComponent
                 prefs.getBoolean(PREFERENCE_VISIBLE_KEY, false));
 
         _setPrefs(prefs);
-        refreshPersistedState();
+
+        // move this operation to a separate thread since it is expensive (~600ms)
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                refreshPersistedState();
+            }
+        });
 
         RootLayoutWidget root = (RootLayoutWidget) _mapView.getComponentExtra(
                 ROOT_LAYOUT_EXTRA);

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/hashtags/StickyHashtags.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/hashtags/StickyHashtags.java
@@ -56,7 +56,14 @@ public class StickyHashtags implements Runnable, MapEventDispatchListener {
         _mapView.getMapEventDispatcher().addMapEventListener(
                 MapEvent.ITEM_REMOVED, this);
 
-        _thread.exec();
+        // hack to delay loading of hash tags until after StateSaver comes up
+        // TODO: replace timer with broadcast sent from StateSaver to a receiver here
+        mapView.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                _thread.exec();
+            }
+        }, 200);
     }
 
     public void dispose() {

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/location/LocationMapComponent.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/location/LocationMapComponent.java
@@ -1112,34 +1112,37 @@ public class LocationMapComponent extends AbstractMapComponent implements
                     Log.d(TAG, "gps detected correct mode: " + gpsEnabled);
 
                     if (!gpsEnabled) {
-                        HintDialogHelper
-                                .showHint(
-                                        context,
-                                        context.getString(
-                                                R.string.location_mode_title),
-                                        context.getString(
-                                                R.string.location_mode_desc),
-                                        "gps.device.mode",
-                                        new HintDialogHelper.HintActions() {
-                                            @Override
-                                            public void preHint() {
+                        // hack to show hint dialog after a 5 second delay to prevent ANRs
+                        // during initial app launch
+                        // TODO: replace with broadcast receiver that keys off of plugin map
+                        //       components done loading event
+                        _mapView.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                HintDialogHelper
+                                        .showHint(
+                                                context,
+                                                context.getString(
+                                                        R.string.location_mode_title),
+                                                context.getString(
+                                                        R.string.location_mode_desc),
+                                                "gps.device.mode",
+                                                new HintDialogHelper.HintActions() {
+                                                    @Override
+                                                    public void preHint() {
 
-                                            }
+                                                    }
 
-                                            @Override
-                                            public void postHint() {
-                                                try {
-                                                    final Intent intent = new Intent(
-                                                            Settings.ACTION_LOCATION_SOURCE_SETTINGS);
-                                                    _mapView.getContext()
-                                                            .startActivity(
-                                                                    intent);
-                                                } catch (ActivityNotFoundException ane) {
-                                                    Log.d(TAG,
-                                                            "no Settings.ACTION_LOCATION_SOURCE_SETTINGS activity found on this device");
-                                                }
-                                            }
-                                        }, false);
+                                                    @Override
+                                                    public void postHint() {
+                                                        final Intent intent = new Intent(
+                                                                Settings.ACTION_LOCATION_SOURCE_SETTINGS);
+                                                        _mapView.getContext()
+                                                                .startActivity(intent);
+                                                    }
+                                                }, false);
+                            }
+                        }, 5000);
                     }
                 }
 

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/routes/elevation/ProcessRouteThread.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/routes/elevation/ProcessRouteThread.java
@@ -162,7 +162,7 @@ public class ProcessRouteThread implements Runnable,
         if (!disposed) {
             disposed = true;
             _prefs.unregisterOnSharedPreferenceChangeListener(this);
-            selfPresenter.stop();
+            selfPresenter.stopProcessing(); // don't block main thread in dispose()
             lThread.dispose(false);
         }
     }

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/routes/elevation/SelfPresenter.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/routes/elevation/SelfPresenter.java
@@ -72,19 +72,28 @@ public class SelfPresenter {
         }
     }
 
+    /**
+     * Stop processing route info (thread safe)
+     */
     public void stop() {
         synchronized (this) {
-            if (processThread == null)
-                return;
-
-            _running = false;
-            Log.d(TAG, "stopping processing the route information for: "
-                    + title);
-            processThread.interrupt();
-            processThread = null;
-            _geoPoint = new GeoPointMetaData[] {};
+            stopProcessing();
         }
 
+    }
+
+    /**
+     * Stop processing route info (non thread safe)
+     */
+    public void stopProcessing() {
+        if (processThread == null)
+            return;
+
+        _running = false;
+        Log.d(TAG, "stopping processing the route information for: " + title);
+        processThread.interrupt();
+        processThread = null;
+        _geoPoint = new GeoPointMetaData[] {};
     }
 
     /**

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/update/AppVersionUpgrade.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/update/AppVersionUpgrade.java
@@ -5,6 +5,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -44,10 +48,22 @@ public class AppVersionUpgrade {
 
     public static boolean OVERLAYS_MIGRATED = false;
 
+    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
+
     /**
      * Provides a central place to run all directory shuffles for components
      */
     public synchronized static void onUpgrade(Context context) {
+        // do the file I/O on a background thread to prevent ANR
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                upgrade(context);
+            }
+        });
+    }
+
+    private static void upgrade(Context context) {
         Log.d(TAG, "Migrating directories");
         FileSystemUtils.init();
 

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/update/ProductProviderManager.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/update/ProductProviderManager.java
@@ -643,8 +643,9 @@ public class ProductProviderManager extends BroadcastReceiver {
                 _builder.setProgress(100, progress[0].progress, false);
                 _builder.setContentText(progress[0].message);
 
-                _notifyManager.notify(NOTIF_ID,
-                        _builder.build());
+                // commenting out because this causes the UI thread to hang for 1 minute on initial app install
+//                _notifyManager.notify(NOTIF_ID,
+//                        _builder.build());
             }
         }
 

--- a/atak/ATAK/app/src/main/java/com/atakmap/android/vehicle/VehicleMapComponent.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/vehicle/VehicleMapComponent.java
@@ -27,6 +27,8 @@ import com.atakmap.map.AtakMapView;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Implements full sized vehicle support that scale correctly with the 
@@ -46,6 +48,7 @@ public class VehicleMapComponent extends AbstractMapComponent {
     private VehicleModelPallet _modelPallet;
     private double _mapRes;
     private AtakMapView.OnMapMovedListener _mapMovedListener;
+    private static final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     @Override
     public void onCreate(Context context, Intent intent, final MapView view) {
@@ -84,7 +87,12 @@ public class VehicleMapComponent extends AbstractMapComponent {
         view.addOnMapMovedListener(_mapMovedListener);
 
         // Load file listing for vehicle models
-        VehicleModelCache.getInstance().rescan();
+        executorService.execute(new Runnable() {
+            @Override
+            public void run() {
+                VehicleModelCache.getInstance().rescan();
+            }
+        });
         _captureService = new GLOffscreenCaptureService();
 
         // 3D vehicle models layer


### PR DESCRIPTION
As mentioned on issue #141, this PR is a collection of miscellaneous fixes to resolve ANR issues seen mainly on MSI Android devices after initial launch of ATAK, and include moving file i/o and network processing from UI thread to background threads.

These are just suggested fixes at this point, our AOSP implementation seems to enforce a stricter ANR policy than most Google Android devices but we have noticed ANRs in the latest 4.5+ playstore versions on some Samsung models so perhaps some of these changes might be beneficial.

Feel free to ignore most or all of this PR if there are other changes in the works or planned to revisit the threading model at startup (see this comment: https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV/blob/366e73c53bf58cc71c28500ed3e345fe9a97e334/atak/ATAK/app/src/main/java/com/atakmap/app/ATAKActivity.java#L866)