### PR TITLE
#189 Modify NotificationService to use AIDL to show how to interact w…

### DIFF
--- a/plugin-examples/helloworld/app/build.gradle
+++ b/plugin-examples/helloworld/app/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
     def takdevVersion = '2.+'
 
-    def getValueFromPropertiesFile = { propFile, key ->
+    ext.getValueFromPropertiesFile = { propFile, key ->
         if(!propFile.isFile() || !propFile.canRead())
             return null
         def prop = new Properties()

--- a/plugin-examples/helloworld/app/src/main/AndroidManifest.xml
+++ b/plugin-examples/helloworld/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.atakmap.android.helloworld.plugin">
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
     <application 
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
@@ -10,7 +12,6 @@
         android:theme="@style/AppTheme" >
         <meta-data android:name="plugin-api" android:value="${atakApiVersion}"/>
         <meta-data android:name="app_desc" android:value="@string/app_desc"/>
-
 
   
         <provider android:name="com.javacodegeeks.android.contentprovidertest.BirthProvider"

--- a/plugin-examples/helloworld/app/src/main/aidl/com/atakmap/android/helloworld/plugin/INotificationService.aidl
+++ b/plugin-examples/helloworld/app/src/main/aidl/com/atakmap/android/helloworld/plugin/INotificationService.aidl
@@ -1,0 +1,8 @@
+// INotificationService.aidl
+package com.atakmap.android.helloworld.plugin;
+
+// Declare any non-default types here with import statements
+
+interface INotificationService {
+    void createNotification(int notificationId, String notificationText);
+}

--- a/plugin-examples/helloworld/app/src/main/java/com/atakmap/android/helloworld/notification/NotificationService.java
+++ b/plugin-examples/helloworld/app/src/main/java/com/atakmap/android/helloworld/notification/NotificationService.java
@@ -2,6 +2,7 @@
 package com.atakmap.android.helloworld.notification;
 
 import com.atakmap.android.helloworld.plugin.BuildConfig;
+import com.atakmap.android.helloworld.plugin.INotificationService;
 import com.atakmap.android.helloworld.plugin.R;
 
 import android.app.NotificationChannel;
@@ -11,6 +12,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.IBinder;
 
+import android.os.RemoteException;
 import android.util.Log;
 
 import android.app.Notification;
@@ -40,10 +42,19 @@ import android.app.PendingIntent;
 public class NotificationService extends Service {
 
     private final static String TAG = "NotificationService";
+    private Notification.Builder nb;
+    private NotificationManager notificationManager;
+    private final int NOTIFICATION_ID = 9999;
+    private final INotificationService.Stub binder = new INotificationService.Stub() {
+        @Override
+        public void createNotification(int notificationId, String notificationText) throws RemoteException {
+            NotificationService.this.createNotification(notificationId,notificationText);
+        }
+    };
 
     @Override
     public IBinder onBind(Intent intent) {
-        return null;
+        return binder;
     }
 
     @Override
@@ -53,7 +64,7 @@ public class NotificationService extends Service {
         Log.d(TAG,
                 "getting ready to show the notification, can never use notification compat.");
 
-        NotificationManager notificationManager = (NotificationManager) getSystemService(
+        notificationManager = (NotificationManager) getSystemService(
                 NOTIFICATION_SERVICE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -77,7 +88,6 @@ public class NotificationService extends Service {
         PendingIntent appIntent = PendingIntent.getActivity(this, 0,
                 atakFrontIntent, 0);
 
-        Notification.Builder nb;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             nb = new Notification.Builder(this,
                     "com.atakmap.android.helloworld.def");
@@ -85,14 +95,19 @@ public class NotificationService extends Service {
             nb = new Notification.Builder(this);
         }
 
-        nb.setContentTitle("Custom Notification").setContentText("Test Icon")
+        nb.setContentTitle("Custom Notification").setContentText("Notification service is running")
                 .setSmallIcon(R.drawable.abc)
                 .setContentIntent(appIntent);
         nb.setOngoing(false);
         nb.setAutoCancel(true);
 
-        notificationManager.notify(9999, nb.build());
-
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForeground(NOTIFICATION_ID, nb.build());
+        }
     }
 
+    private void createNotification(int notificationId, String notificationText) {
+        nb.setContentText(notificationText);
+        notificationManager.notify(notificationId, nb.build());
+    }
 }

--- a/plugin-examples/helloworld/app/src/main/res/layout/hello_world_layout.xml
+++ b/plugin-examples/helloworld/app/src/main/res/layout/hello_world_layout.xml
@@ -488,6 +488,14 @@
                 android:text="Fake Content Provider" />
 
             <Button
+                android:id="@+id/pluginNotificationService"
+                style="@style/darkButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="6dp"
+                android:text="Notification Service" />
+
+            <Button
                 android:id="@+id/pluginNotification"
                 style="@style/darkButton"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
…ith a service

Also covers #190 which is supposed to be fixed in 4.6 already

It terms of how this works on the UI:

- The user must click the Notification Service button to start the service.  An icon showing that the service is running is displayed as part of the normal Android process for foreground services
- The user can them click Notification with Plugin Icon to generate notifications as desired through the service interface