### PR TITLE
Made EmergencyAlertReceiver accessible from plugins

### DIFF
--- a/atak/ATAK/app/src/main/java/com/atakmap/android/emergency/EmergencyAlertReceiver.java
+++ b/atak/ATAK/app/src/main/java/com/atakmap/android/emergency/EmergencyAlertReceiver.java
@@ -35,6 +35,7 @@ import java.util.TimerTask;
 public class EmergencyAlertReceiver extends BroadcastReceiver {
 
     private static final String TAG = "EmergencyAlertReceiver";
+    private static final EmergencyAlertReceiver _instance;
 
     final static String ALERT_EVENT = "com.atakmap.android.emergency.ALERT_EVENT";
     final static String CANCEL_EVENT = "com.atakmap.android.emergency.CANCEL_EVENT";
@@ -45,7 +46,7 @@ public class EmergencyAlertReceiver extends BroadcastReceiver {
      * Simple container for an ongoing alert
      * Note, we could track additional data if necessary, e.g. first/last report time, CoT type, etc
      */
-    static class EmergencyAlert extends WarningComponent.Alert {
+    public static class EmergencyAlert extends WarningComponent.Alert {
         private String type;
         private String message;
         private GeoPoint point;
@@ -199,6 +200,14 @@ public class EmergencyAlertReceiver extends BroadcastReceiver {
         _initialized = false;
 
         _alertGroup = _mapView.getRootGroup().findMapGroup("Emergency");
+        _instance = this;
+    }
+
+    public static EmergencyAlertReceiver getInstance() {
+        if (_instance == null) {
+            throw new IllegalStateException("EmergencyAlertReceiver not initialized yet");
+        }
+        return _instance;
     }
 
     @Override
@@ -472,7 +481,7 @@ public class EmergencyAlertReceiver extends BroadcastReceiver {
         return null;
     }
 
-    synchronized int getAlertCount() {
+    public synchronized int getAlertCount() {
         return _alerts.size();
     }
 
@@ -480,7 +489,7 @@ public class EmergencyAlertReceiver extends BroadcastReceiver {
      * Get list of Emergency alerts
      * @return the list of emergency alerts
      */
-    synchronized List<EmergencyAlert> getAlerts() {
+    public synchronized List<EmergencyAlert> getAlerts() {
         return new ArrayList<>(_alerts);
     }
 


### PR DESCRIPTION
I've found myself needing to access the list of `EmergencyAlert` objects from a plugin, but I don't have access to the list of them, nor the class itself! So I've added:
- public access modifier to the `EmergencyAlert` class
- `EmergencyAlertReceiver.getInstance()` static method, since it's only being created in one place (`EmergencyAlertComponent`) and I'd like to get access to the list of alerts!
- public access modifiers to some methods in `EmergencyAlertReceiver `

I'm aware that ATAK is now on 4.8 (and not the 4.5 that I'm committing to), but in case this isn't available in the later SDKs I thought it might be useful for other plugin devs 😃 