### PR TITLE
Fix GitHub Assemble Action

### DIFF
--- a/.github/workflows/assemble-sdk.yml
+++ b/.github/workflows/assemble-sdk.yml
@@ -25,7 +25,6 @@ jobs:
         git lfs checkout
     - name: set environment
       run: |
-        apt -y install ant
         apt -y install apg
         apt -y install dos2unix
         apt -y install autoconf
@@ -45,10 +44,17 @@ jobs:
         echo "ANDROID_BUILD_TOOLS=29.0.3" >> $GITHUB_ENV
         echo "ANDROID_SDK_TOOLS=4333796" >> $GITHUB_ENV
         echo "NDK_VERSION=12b" >> $GITHUB_ENV
+        echo "ANT_VERSION=1.10.14" >> $GITHUB_ENV
         echo "KEYSTORE_ALIAS=CI" >> $GITHUB_ENV
         echo "KEYSTORE_STORE_PASSWORD=$(apg -a 1 -n 1 -m 16 -x 16 -E '\')" >> $GITHUB_ENV
         echo "KEYSTORE_KEY_PASSWORD=$(apg -a 1 -n 1 -m 16 -x 16 -E '\')" >> $GITHUB_ENV
         mkdir $HOME/secrets
+    - name: install Apache Ant build tool
+      run: |
+        wget --quiet --tries=0 --output-document=ant.zip https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}-bin.zip
+        unzip -qq ant.zip
+        echo "$PWD/apache-ant-${ANT_VERSION}/bin/" >> $GITHUB_PATH
+        echo "ANT_HOME=$PWD/apache-ant-${ANT_VERSION}" >> $GITHUB_ENV
     - name: set up Android SDK
       run: |
        wget --quiet --tries=0 --output-document=android-sdk.zip https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_TOOLS}.zip;

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 - 2021-10-29 Matt B w20682@motorolasolutions.com
 - 2022-01-11 Yuvraaj Kelkar uv@crave.io
+- 2023-12-28 Todd Willey xtoddx@gmail.com
 
 ## Note for U.S. Federal Employees
 


### PR DESCRIPTION
# Problem

The assemble action on PRs derives from the openjdk:8-jdk container, but during the update process install of apache ant brings in OpenJDK 11.

The javah command for jni interactions was removed in version 10, so using version 11 breaks the build process [while building commoncommo](https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV/blob/master/commoncommo/jni/native/Makefile#L100)

# Solution

In order to use the expected JDK, install ant manually instead of from deb package.

# Ability to merge

✅ Evidence of a successful run (See "Validation" below)
✅ Signed-off and accepted Developer Certificate of Origin (CONTRIBUTORS.md change in this PR)
✅ Reasonable scope and size for review (the PR text you're reading is much larger than the change)

# Discussion

## Validation

Here is the successful run using the new action: [https://github.com/xtoddx/ATAK-CIV/actions/runs/7351078940/job/20013833196?pr=1](xtoddx/ATAK-CIV #1)

Since github deletes action logs after a while, I'll provide some screenshots as well.

First, we see that ant is no longer installed by apt:
<img width="445" alt="Screen Shot 2023-12-28 at 6 02 56 PM" src="https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV/assets/6172/f151aedd-df8b-4fad-a0aa-3e2452033001">

Then, we see the new step executes successfully:
<img width="840" alt="Screen Shot 2023-12-28 at 6 03 43 PM" src="https://github.com/deptofdefense/AndroidTacticalAssaultKit-CIV/assets/6172/c35818b4-090b-46eb-8a09-725f26b763bd">

Cliking the link above will show that the entire action was successful.

## Changes to Environment

This commit followed the existing pattern for keeping version numbers in the environment, and added `ANT_VERSION` for this purpose.

Additionally, `ANT_HOME` is added per the (ant manual)[https://ant.apache.org/manual/index.html], and `PATH` is updated so the ant binary can be found.

## Long term

There is room for a more long-term fix, by using javac -h instead of javah to build headers form the jni components. Since the public project is a minor version behind what is released through other channels like the play store, I'll reserve that change in case it has already happend internally but not made it to github.